### PR TITLE
refactor/add-clickable-day-forecast

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -10,6 +10,7 @@ import SearchScreen from './src/screens/search.screen';
 import { SCREENS } from './src/constants/screens.constant';
 import FeedbackScreen from './src/screens/feedback.screen';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import DayScreen from './src/screens/day.screen';
 
 const Drawer = createNativeStackNavigator();
 
@@ -21,9 +22,10 @@ function App(): JSX.Element {
       }}>
         <Drawer.Screen name={SCREENS.home} component={MainScreen} />
         <Drawer.Screen name={SCREENS.feedback} component={FeedbackScreen} />
-        <Drawer.Screen name={SCREENS.nolocation} component={NoLocationScreen} options={{drawerItemStyle: { height: 0 }}} />
-        <Drawer.Screen name={SCREENS.hourly} component={HourScreen} options={{drawerItemStyle: { height: 0 }}} />
-        <Drawer.Screen name={SCREENS.search} component={SearchScreen} options={{drawerItemStyle: { height: 0 }}} />
+        <Drawer.Screen name={SCREENS.nolocation} component={NoLocationScreen} />
+        <Drawer.Screen name={SCREENS.hourly} component={HourScreen} />
+        <Drawer.Screen name={SCREENS.day} component={DayScreen} />
+        <Drawer.Screen name={SCREENS.search} component={SearchScreen} />
       </Drawer.Navigator>
     </NavigationContainer>
   );

--- a/src/common/types.common.ts
+++ b/src/common/types.common.ts
@@ -1,7 +1,8 @@
-import { WeatherForecast } from "../utils/locationforecast";
+import { ForecastTimestep, WeatherForecast } from "../utils/locationforecast";
 
 export type RootDrawerParamList = {
-  Hourly: { name: string, forecast: WeatherForecast };
+  Hourly: { name: string, forecast: WeatherForecast, title: string };
+  Day: { name: string, forecast: Array<ForecastTimestep> };
   NoLocation: undefined;
   Search: undefined;
   Home: undefined;

--- a/src/components/AppBar.tsx
+++ b/src/components/AppBar.tsx
@@ -50,7 +50,7 @@ const AppBar = (props: AppBarProps) => {
               <Menu.Item onPress={() => { closeMenu(); }} style={styles.menuItem} title="Favourites" />
               <Menu.Item onPress={() => { closeMenu(); }} style={styles.menuItem} title="About the app" />
               <Menu.Item onPress={() => { closeMenu(); }} style={styles.menuItem} title="Settings" />
-              <Menu.Item onPress={() => { props.navigation.navigate(SCREENS.feedback); closeMenu(); }} style={styles.menuItem} title="Give feedback" />
+              <Menu.Item onPress={() => { closeMenu(); props.navigation.navigate(SCREENS.feedback); }} style={styles.menuItem} title="Give feedback" />
               <Menu.Item onPress={() => { closeMenu(); }} style={styles.menuItem} title="Help" />
             </Menu>
           </View>

--- a/src/components/AppBar.tsx
+++ b/src/components/AppBar.tsx
@@ -16,8 +16,8 @@ type AppBarProps = {
 };
 
 const AppBar = (props: AppBarProps) => {
-  const tooLong = props.location.length > 15;
-  const fmtLocation = tooLong ? `${props.location?.slice(0, 18)}...` : props.location;
+  const tooLong = props.location.length > 12;
+  const fmtLocation = tooLong ? `${props.location?.slice(0, 12)}...` : props.location;
 
   const showSearch = useRoute().name !== SCREENS.search;
   const [visible, setVisible] = React.useState(false);

--- a/src/components/DayRow.tsx
+++ b/src/components/DayRow.tsx
@@ -13,13 +13,13 @@ function getWeatherIcon(timesteps: Array<ForecastTimestep>): string | undefined 
   let icon = undefined;
 
   if (timeIsAfter4) {
-      const timestep = timesteps.find(t => t.time = `${today} 04:00:00Z`);
-      icon = timestep?.data.next_12_hours?.summary?.symbol_code;
+    const timestep = timesteps.find(t => t.time = `${today} 04:00:00Z`);
+    icon = timestep?.data.next_12_hours?.summary?.symbol_code;
   }
 
   if (timeIsAfter6) {
-      const timestep = timesteps.find(t => t.time = `${today} 06:00:00Z`);
-      icon = timestep?.data.next_12_hours?.summary?.symbol_code;
+    const timestep = timesteps.find(t => t.time = `${today} 06:00:00Z`);
+    icon = timestep?.data.next_12_hours?.summary?.symbol_code;
   }
 
   return icon;

--- a/src/components/FiveDays.tsx
+++ b/src/components/FiveDays.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View } from 'react-native';
+import { TouchableOpacity, View } from 'react-native';
 import { Text } from 'react-native-paper';
 import moment from 'moment';
 
@@ -20,6 +20,8 @@ function groupForecastsByDay(
 
 type DailyForecastProps = {
     forecast?: WeatherForecast;
+    name: string;
+    onClick: (forecast: Array<ForecastTimestep>) => void;
 }
 function FiveDays(props: DailyForecastProps): JSX.Element {
     if (props.forecast) {
@@ -29,7 +31,7 @@ function FiveDays(props: DailyForecastProps): JSX.Element {
         const grouped = groupForecastsByDay(filtered);
         const fiveDayForecast = Object.entries(grouped).slice(0, 5);
         return <View style={{ paddingLeft: 12, paddingRight: 12, marginTop: 40 }}>
-            {fiveDayForecast.map(([k, val]) => <DayRow key={k} day={k} forecast={val} />)}
+            {fiveDayForecast.map(([k, val]) => <TouchableOpacity key={k} onPress={() => props.onClick(val)}><DayRow day={k} forecast={val} /></TouchableOpacity>)}
         </View>
     }
 

--- a/src/components/HourlyTable.tsx
+++ b/src/components/HourlyTable.tsx
@@ -8,12 +8,13 @@ import { ForecastTimestep } from '../utils/locationforecast';
 
 type HourlyTableProps = {
   forecast: Array<ForecastTimestep>;
+  title: string;
 };
 
 function HourlyTable(props: HourlyTableProps): JSX.Element {
   return (
     <View style={styles.container}>
-      <Text style={styles.header}>Hourly today</Text>
+      <Text style={styles.header}>{props.title}</Text>
       <View style={{ paddingLeft: 12, paddingRight: 12, marginTop: 5 }}>
         <DataTable>
           <DataTable.Header>
@@ -23,7 +24,7 @@ function HourlyTable(props: HourlyTableProps): JSX.Element {
             <DataTable.Title numeric>Rain mm</DataTable.Title>
             <DataTable.Title numeric>Wind km/h</DataTable.Title>
           </DataTable.Header>
-          <ScrollView>
+          <ScrollView snapToStart={false}>
             {props.forecast.map((hour) => (
               <DataTable.Row key={hour.time}>
                 <DataTable.Cell>{moment(hour.time).format('HH:mm')}</DataTable.Cell>

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -39,7 +39,7 @@ export const Search = ({location, setLocation}: SearchProps) => {
         onSelectItem={handleSelect}
         dataSet={dataset}
         inputContainerStyle={styles.searchBar}
-        debounce={600}
+        debounce={3000}
         showChevron={true}
         showClear={true}
       />

--- a/src/constants/screens.constant.ts
+++ b/src/constants/screens.constant.ts
@@ -1,7 +1,8 @@
-export const SCREENS: { [k: string]: "Home" | "Hourly" | "NoLocation" | "Search" | "Feedback" } = {
+export const SCREENS: { [k: string]: "Home" | "Hourly" | "NoLocation" | "Search" | "Feedback" | "Day" } = {
   home: 'Home',
   nolocation: 'NoLocation',
   hourly: 'Hourly',
   search: 'Search',
   feedback: 'Feedback',
+  day: 'Day',
 };

--- a/src/screens/day.screen.tsx
+++ b/src/screens/day.screen.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { ImageBackground, StyleSheet, View } from 'react-native';
+import moment from 'moment';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+
+import appBackground from '../../assets/app-bg-faded.png';
+import AppBar from '../components/AppBar';
+import { ForecastTimestep } from '../utils/locationforecast';
+import HourlyTable from '../components/HourlyTable';
+import { RootDrawerParamList } from '../common';
+
+function sortTimesteps(timesteps: Array<ForecastTimestep>): Array<ForecastTimestep> {
+  return timesteps.sort((first, second) => moment(first.time).isBefore(moment(second.time)) ? -1 : 1);
+}
+
+type ScreenProps = NativeStackScreenProps<RootDrawerParamList, 'Day'>;
+function DayScreen({ route, navigation }: ScreenProps): JSX.Element {
+  const { forecast, name } = route.params;
+  const sorted = sortTimesteps(forecast);
+  return (
+    <SafeAreaView>
+      <View style={styles.wrapper}>
+        <ImageBackground source={appBackground} style={styles.bg}>
+          <AppBar location={name} navigation={navigation} />
+          <HourlyTable forecast={sorted} title={moment(forecast[0].time).format('dddd')} />
+        </ImageBackground>
+      </View>
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  wrapper: {
+    flexDirection: 'column',
+    height: '100%',
+    width: '100%',
+    margin: 0,
+    padding: 0,
+    overflow: 'scroll',
+  },
+  bg: {
+    height: '100%',
+  },
+  container: {
+    flexDirection: 'column',
+    flex: 1,
+  },
+  header: {
+    fontSize: 20,
+    fontFamily: 'Rajdhani-Regular',
+    paddingRight: 20,
+    paddingLeft: 20,
+    paddingTop: 20,
+  },
+});
+
+export default DayScreen;

--- a/src/screens/hour.screen.tsx
+++ b/src/screens/hour.screen.tsx
@@ -22,7 +22,7 @@ function sortTimesteps(timesteps: Array<ForecastTimestep>): Array<ForecastTimest
 
 type ScreenProps = NativeStackScreenProps<RootDrawerParamList, 'Hourly'>;
 function HourScreen({ route, navigation }: ScreenProps): JSX.Element {
-  const { forecast, name } = route.params;
+  const { forecast, name, title } = route.params;
   const timesteps = getTodaysTimesteps(forecast);
   const sorted = sortTimesteps(timesteps);
   return (
@@ -30,7 +30,7 @@ function HourScreen({ route, navigation }: ScreenProps): JSX.Element {
       <View style={styles.wrapper}>
         <ImageBackground source={appBackground} style={styles.bg}>
           <AppBar location={name} navigation={navigation} />
-          <HourlyTable forecast={sorted} />
+          <HourlyTable forecast={sorted} title={title}/>
         </ImageBackground>
       </View>
     </SafeAreaView>

--- a/src/screens/main.screen.tsx
+++ b/src/screens/main.screen.tsx
@@ -13,6 +13,7 @@ import type { AppDispatch, RootState } from '../store'
 import { SCREENS } from '../constants/screens.constant';
 import { getPreciseLocation } from '../store/location.slice';
 import { getLocationForecast } from '../store/forecast.slice';
+import { ForecastTimestep } from '../utils/locationforecast';
 
 type ScreenProps = {
   navigation: NativeStackNavigationProp<ParamListBase>;
@@ -36,6 +37,8 @@ const MainScreen = ({ navigation }: ScreenProps) => {
     }
   }, [locationError]);
 
+  const onClick = (name: string) => (forecast: Array<ForecastTimestep>) => navigation.navigate(SCREENS.day, { name, forecast });
+
   if (forecastError) {
     <SafeAreaView>
       <View style={styles.wrapper}>
@@ -54,8 +57,8 @@ const MainScreen = ({ navigation }: ScreenProps) => {
           <ImageBackground source={appBackground} style={styles.bg}>
             <AppBar location={name} navigation={navigation} />
             <ScrollView>
-              <TouchableOpacity onPress={() => navigation.navigate(SCREENS.hourly, { forecast, name })}><Today forecast={forecast} /></TouchableOpacity>
-              <FiveDays forecast={forecast} />
+              <TouchableOpacity onPress={() => navigation.navigate(SCREENS.hourly, { forecast, name, title: 'Hourly Today' })}><Today forecast={forecast} /></TouchableOpacity>
+              <FiveDays name={name} forecast={forecast} onClick={onClick(name)} />
             </ScrollView>
           </ImageBackground>
         </View>


### PR DESCRIPTION
- refactored landing screen
- allowed viewing of hourly data for each day in the five day forecast
- increased search debounce rate to 3000