### PR TITLE
refactor/centralize-api-requests

### DIFF
--- a/src/common/types.common.ts
+++ b/src/common/types.common.ts
@@ -1,8 +1,82 @@
 import { CAPAlert } from "../lib/cap-client/alert";
-import { Forecast } from "../utils/locationforecast";
+
+export interface Forecast {
+  type: string;
+  geometry: {
+    type: 'Point';
+    coordinates: number[];
+  };
+  properties: {
+    meta: {
+      updated_at: string;
+      units:
+      {
+        air_pressure_at_sea_level?: string;
+        air_temperature?: string;
+        air_temperature_max?: string;
+        air_temperature_min?: string;
+        cloud_area_fraction?: string;
+        cloud_area_fraction_high?: string;
+        cloud_area_fraction_medium?: string;
+        cloud_area_fraction_low?: string;
+        dew_point_temperature?: string;
+        fog_area_fraction?: string;
+        precipitation_amount?: string;
+        relative_humidity?: string;
+        ultraviolet_index_clear_sky?: string;
+        wind_from_direction?: string;
+        wind_speed?: string;
+      };
+    };
+    timeseries: ForecastTimestep[];
+  };
+}
+
+export interface ForecastDetails {
+  air_temperature_min?: number;
+  air_temperature_max?: number;
+  precipitation_amount?: number;
+  precipitation_amount_max?: number;
+  precipitation_amount_min?: number;
+  probability_of_precipitation?: number;
+  probability_of_thunder?: number;
+  ultraviolet_index_clear_sky_max?: number;
+}
+
+export interface ForecastPeriod {
+  details?: ForecastDetails;
+  summary?: {
+    symbol_code?: string;
+  };
+}
+
+export interface ForecastTimestep {
+  time: string;
+  data: {
+    instant: {
+      details: {
+        air_pressure_at_sea_level?: number;
+        air_temperature?: number;
+        cloud_area_fraction?: number;
+        cloud_area_fraction_high?: number;
+        cloud_area_fraction_medium?: number;
+        cloud_area_fraction_low?: number;
+        dew_point_temperature?: number;
+        fog_area_fraction?: number;
+        relative_humidity?: number;
+        ultraviolet_index_clear_sky?: number;
+        wind_from_direction?: number;
+        wind_speed?: number;
+      };
+    };
+    next_1_hours?: ForecastPeriod;
+    next_6_hours?: ForecastPeriod;
+    next_12_hours?: ForecastPeriod;
+  };
+}
 
 export type RootDrawerParamList = {
-  Hourly: { location: string, forecast: Forecast, dayString: string|null, noValuesBefore: boolean, title: string };
+  Hourly: { location: string, forecast: Forecast, dayString: string | null, noValuesBefore: boolean, title: string };
   NoLocation: undefined;
   Search: undefined;
   Home: undefined;

--- a/src/components/LocationRow.tsx
+++ b/src/components/LocationRow.tsx
@@ -7,7 +7,7 @@ import { useForecast } from '../hooks/current-forecast.hook';
 import { District } from '../constants/districts.constant';
 import weatherIcons from '../constants/weathericons.constant';
 import { WeatherData } from '../utils/weatherData';
-import { Forecast } from '../utils/locationforecast';
+import { Forecast } from '../common';
 
 
 type LocationRowProps = {

--- a/src/hooks/current-forecast.hook.ts
+++ b/src/hooks/current-forecast.hook.ts
@@ -1,8 +1,9 @@
 import { useEffect, useState } from 'react';
 import Axios from 'axios';
-import { LOGGER } from '../lib';
 
-import { Forecast } from '../utils/locationforecast';
+import { LOGGER } from '../lib';
+import { Forecast } from '../common';
+import { Forecaster } from '../utils/locationforecast';
 
 type ReturnType = [
   loading: boolean,
@@ -15,29 +16,22 @@ export function useForecast(latitude: number, longitude: number): ReturnType {
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<Error>();
 
-  const API_URL = 'https://api.met.no/weatherapi/locationforecast/2.0';
-  const USER_AGENT = 'met_malawi';
-
   useEffect(() => {
     const fetchData = async () => {
-      const url = `${API_URL}?lat=${latitude}&lon=${longitude}`
+      const forecaster = new Forecaster();
       try {
-        const response = await Axios.get(url, { timeout: 20000, headers: { 'User-Agent': USER_AGENT, 'Accept-Encoding': 'gzip'} });
-        setForecast(response.data)
         setLoading(false);
-      
+        setForecast(await forecaster.getForecast(latitude, longitude));
       } catch (error) {
+        setLoading(false);
         if (Axios.isAxiosError(error)) {
           LOGGER.error('Axios error:', error.response?.data || error.message);
         } else {
           LOGGER.error('Non-Axios error:' + error);
         }
-      
         setError(new Error("There was a problem getting the weather. Please try again later."))
-        setLoading(false)
       }
     }
-
     fetchData()
   }, [latitude, longitude]);
 

--- a/src/screens/no-location.screen.tsx
+++ b/src/screens/no-location.screen.tsx
@@ -13,7 +13,7 @@ import { RootDrawerParamList } from '../common';
 import { setForecast } from '../store/forecast.slice';
 import { setLat, setLon, setName } from '../store/location.slice';
 import { SCREENS } from '../constants/screens.constant';
-import { Forecast } from '../utils/locationforecast';
+import { Forecast } from '../common';
 
 type ScreenProps = NativeStackScreenProps<RootDrawerParamList, 'NoLocation'>;
 const NoLocationScreen = ({ navigation }: ScreenProps) => {

--- a/src/utils/forecast.utils.test.ts
+++ b/src/utils/forecast.utils.test.ts
@@ -1,6 +1,6 @@
 import moment from "moment";
 import { getForecastSymbolAtTime, getWeatherIconAtDay } from "./forecast.utils";
-import { ForecastTimestep } from './locationforecast';
+import { ForecastTimestep } from '../common';
 
 
 describe("select correct weather symbol for today's forecast", () => {
@@ -48,7 +48,7 @@ describe("select correct weather symbol for a single day", () => {
         forecast[12].data.next_1_hours = undefined
         expect(getWeatherIconAtDay(forecast)).toBeUndefined()
     })
-    
+
 })
 
 /**

--- a/src/utils/forecast.utils.ts
+++ b/src/utils/forecast.utils.ts
@@ -1,6 +1,7 @@
-import { FORECAST_DESCRIPTIONS } from '../constants/forecast-descriptions.constant';
 import moment from 'moment';
-import { ForecastTimestep } from './locationforecast';
+
+import { FORECAST_DESCRIPTIONS } from '../constants/forecast-descriptions.constant';
+import { ForecastTimestep } from '../common';
 
 
 export function getForecastDescription(key: string): string {

--- a/src/utils/locationforecast.ts
+++ b/src/utils/locationforecast.ts
@@ -1,121 +1,32 @@
+import Axios from 'axios';
+import { Forecast } from '../common';
+
 /**
  * Download a weather forecast from api.met.no/weatherapi/locationforecast or a similar service.
  *
  * Ensures that a uses agent is set on each request.
  */
 export class Forecaster {
-  readonly userAgent: string;
-  readonly baseURL: string =
-    'https://api.met.no/weatherapi/locationforecast/2.0/';
+  private readonly userAgent: string = 'DCCMS - Zanyengo v1';
+  private readonly basURL: string = 'https://api.met.no/weatherapi/locationforecast/2.0';
 
-  constructor(userAgent: string, baseURL?: string) {
-    this.userAgent = userAgent;
-    if (baseURL !== undefined) {
-      this.baseURL = baseURL;
-    }
+  constructor(userAgent?: string, baseURL?: string) {
+    userAgent && (this.userAgent = userAgent);
+    baseURL && (this.basURL = baseURL);
   }
 
-  async getForecast(
-    latitude: number,
-    longitude: number,
-    altitude?: number,
-  ): Promise<Forecast | undefined> {
-    let url =
-      this.baseURL +
-      '?lat=' +
-      latitude.toFixed(4) +
-      '&lon=' +
-      longitude.toFixed(4);
-    if (altitude !== undefined) {
-      url += '&altitude=' + altitude.toFixed(0);
-    }
+  async getForecast(lat: number, lon: number, alt?: number): Promise<Forecast> {
+    let url = `${this.basURL}?lat=${lat.toFixed(4)}&lon=${lon.toFixed(4)}`;
+    alt && (url = `${url}&altitude=${alt}`);
 
-    try {
-      let response = await fetch(url, {
-        headers: {
-          'User-Agent': this.userAgent,
-        },
-      });
-      return await response.json();
-    } catch (err) {
-      const error = err as Error;
-      console.log(error.message);
-      return undefined;
-    }
+    const reqConfig = {
+      headers: {
+        'User-Agent': this.userAgent,
+        'Accept-Encoding': 'gzip',
+      },
+      timeout: 20_000,
+    };
+    const { data } = await Axios.get<Forecast>(url, reqConfig);
+    return data;
   }
-}
-
-export interface Forecast {
-  type: string;
-  geometry: {
-    type: 'Point';
-    coordinates: number[];
-  };
-  properties: {
-    meta: {
-      updated_at: string;
-      units: 
-      {
-        air_pressure_at_sea_level?: string;
-        air_temperature?: string;
-        air_temperature_max?: string;
-        air_temperature_min?: string;
-        cloud_area_fraction?: string;
-        cloud_area_fraction_high?: string;
-        cloud_area_fraction_medium?: string;
-        cloud_area_fraction_low?: string;
-        dew_point_temperature?: string;
-        fog_area_fraction?: string;
-        precipitation_amount?: string;
-        relative_humidity?: string;
-        ultraviolet_index_clear_sky?: string;
-        wind_from_direction?: string;
-        wind_speed?: string;
-      };
-    };
-    timeseries: ForecastTimestep[];
-  };
-}
-
-export interface ForecastDetails {
-  air_temperature_min?: number;
-  air_temperature_max?: number;
-  precipitation_amount?: number;
-  precipitation_amount_max?: number;
-  precipitation_amount_min?: number;
-  probability_of_precipitation?: number;
-  probability_of_thunder?: number;
-  ultraviolet_index_clear_sky_max?: number;
-}
-
-export interface ForecastPeriod {
-  details?: ForecastDetails;
-  summary?: {
-    symbol_code?: string;
-  };
-}
-
-export interface ForecastTimestep {
-  time: string;
-  data: {
-    instant: {
-      details: {
-        air_pressure_at_sea_level?: number;
-        air_temperature?: number;
-        cloud_area_fraction?: number;
-        cloud_area_fraction_high?: number;
-        cloud_area_fraction_medium?: number;
-        cloud_area_fraction_low?: number;
-        dew_point_temperature?: number;      
-        fog_area_fraction?: number;
-        relative_humidity?: number;
-        ultraviolet_index_clear_sky?: number;
-        wind_from_direction?: number;
-        wind_speed?: number;
-      };
-    };
-    next_1_hours?: ForecastPeriod;
-    next_6_hours?: ForecastPeriod;
-    next_12_hours?: ForecastPeriod;
-  };
 }

--- a/src/utils/weatherData.test.ts
+++ b/src/utils/weatherData.test.ts
@@ -1,5 +1,5 @@
 import { DateTime } from "luxon"
-import { Forecast } from "./locationforecast"
+import { Forecast } from "../common"
 import { WeatherData } from "./weatherData"
 
 describe('interpret forecast', () => {
@@ -31,7 +31,7 @@ describe('interpret forecast', () => {
         expect(summary.minTemperature).toBe(18.7)
         expect(summary.maxTemperature).toBe(26.9)
         expect(summary.weatherSymbol).toBe("rain")
-        expect(summary.windSpeed).toBe(4.2*3.6) // wind speed has been converted to km/h
+        expect(summary.windSpeed).toBe(4.2 * 3.6) // wind speed has been converted to km/h
         expect(summary.steps.length).toBe(24)
 
         expect(summary.steps[0].time.toISO()).toBe("2024-01-12T00:00:00.000+02:00")

--- a/src/utils/weatherData.ts
+++ b/src/utils/weatherData.ts
@@ -1,5 +1,5 @@
 import { DateTime } from "luxon";
-import { ForecastTimestep, Forecast } from "./locationforecast";
+import { ForecastTimestep, Forecast } from "../common";
 
 const timeZone = 'Africa/Blantyre'
 
@@ -29,7 +29,7 @@ export class WeatherData {
         let ret = [this.timeSteps[0].time.startOf('day')]
         for (const step of this.timeSteps) {
             const t = step.time.startOf('day')
-            if (!t.equals(ret[ret.length-1]))
+            if (!t.equals(ret[ret.length - 1]))
                 ret.push(t)
         }
         return ret
@@ -42,7 +42,7 @@ export class WeatherData {
      * @noValuesBefore Only get values for timesteps after specified time.
      * @returns A summary of the forecast for the given day.
      */
-    atDay(time: DateTime, noValuesBefore: boolean = false): WeatherDataDaySummary|undefined {
+    atDay(time: DateTime, noValuesBefore: boolean = false): WeatherDataDaySummary | undefined {
         let timeSteps = this.timeSteps
         if (noValuesBefore)
             timeSteps = timeSteps.filter(step => step.time > time)
@@ -89,7 +89,7 @@ export class WeatherDataTimestep {
         this.temperature = timestep.data.instant.details.air_temperature
         this.precipitation_1h = timestep.data.next_1_hours?.details?.precipitation_amount
         this.precipitation_6h = timestep.data.next_6_hours?.details?.precipitation_amount
-        let windSpeed = timestep.data.instant.details.wind_speed 
+        let windSpeed = timestep.data.instant.details.wind_speed
         if (windSpeed) {
             // Convert to km/h
             windSpeed *= 3.6
@@ -117,9 +117,9 @@ export class WeatherDataTimestep {
      * Get the weather symbol for this time step - either for the next hour or for the next six hours.
      */
     weatherSymbol(): string {
-        if (this.weatherSymbol_1h !== undefined) 
+        if (this.weatherSymbol_1h !== undefined)
             return this.weatherSymbol_1h
-        if (this.weatherSymbol_6h !== undefined) 
+        if (this.weatherSymbol_6h !== undefined)
             return this.weatherSymbol_6h
         return "??"
     }
@@ -161,8 +161,8 @@ function getMinMaxTemperature(relevantSteps: WeatherDataTimestep[]): minmax {
     };
 }
 
-function getMaxWindSpeed(relevantSteps: WeatherDataTimestep[]): number| undefined {
-    let max = 0 
+function getMaxWindSpeed(relevantSteps: WeatherDataTimestep[]): number | undefined {
+    let max = 0
     for (const step of relevantSteps) {
         const val = step.windSpeed;
         if (val === undefined) {


### PR DESCRIPTION
- we had code that works with the weather API in multiple places
- remedial step was to move all that to the Forecaster class
- this abstracts away the details of fetching the forecasts
- this way if changes need to be made it is only in in one place